### PR TITLE
added optional prefix to backup name

### DIFF
--- a/src/backup.ts
+++ b/src/backup.ts
@@ -89,7 +89,7 @@ export const backup = async () => {
 
   const date = new Date().toISOString();
   const timestamp = date.replace(/[:.]+/g, '-');
-  const filename = `backup-${timestamp}.tar.gz`;
+  const filename = `${env.BACKUP_FILE_PREFIX}-${timestamp}.tar.gz`;
   const filepath = path.join(os.tmpdir(), filename);
 
   await dumpToFile(filepath);

--- a/src/env.ts
+++ b/src/env.ts
@@ -22,5 +22,9 @@ export const env = envsafe({
     desc: 'Run a backup on startup of this application',
     default: false,
     allowEmpty: true,
+  }),
+  BACKUP_FILE_PREFIX: str({
+    desc: 'Prefix to the file name',
+    default: 'backup',
   })
 })


### PR DESCRIPTION
This adds an optional env variable named `BACKUP_FILE_PREFIX` where the user can customize the name of the backup file (in the case that they push more than one backup source to the same directory).

It defaults to `backup`, so there won't be any logic change in the implementation if the user doesn't modify anything

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit


- **New Features**
	- Introduced a configuration option for customizing backup file prefixes.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->